### PR TITLE
Demo App Experience - first screen auto-request data when launch.

### DIFF
--- a/Pull To Refresh Demo/UsersViewController.swift
+++ b/Pull To Refresh Demo/UsersViewController.swift
@@ -27,6 +27,7 @@ class UsersViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        refresher.refresh()
 
 //        tableView.contentInset = UIEdgeInsets(top: 100, left: 0, bottom: 100, right: 0)
 


### PR DESCRIPTION
Experience. 
We should not have an empty home screen.
I didn't see data When I launched your demo app. I thought the demo was bad.